### PR TITLE
make it more apparent that the app is running in what we consider dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockless/cli",
-  "version": "0.0.1",
+  "version": "0.0.0-development",
   "description": "blockless cli client, manage, interact with and deploy blockless applications.",
   "main": "src/index.ts",
   "bin": {


### PR DESCRIPTION
when using `npm link` and running this in script form, rather than packaged form, make it more apparent. than `v0.0.1`. Makes this `v0.0.0-development`