### PR TITLE
correct escaping when passing string for json

### DIFF
--- a/src/commands/function/invoke.ts
+++ b/src/commands/function/invoke.ts
@@ -141,6 +141,7 @@ export const run = async (options: any) => {
       })
     } else {
       // pass in stdin to the runtime
+      stdinString = stdinString.replace(/"/g, '\\"')
       const result = execSync(`echo "${stdinString}" | ${envString} ${runtimePath} ${manifestPath}`, {
         cwd: path
       }).toString()


### PR DESCRIPTION
when passing a stdin formatted `json` the expected result is that this is decodable. looks like the CLI is breaking this before passing to echo.

expected

`bls function invoke -s {\"foo\":\"bar\"}`

result 

`echo "{"foo":"bar"}" |`

s/b

`echo "{\"foo\":\"bar\"}"`