### PR TITLE
Ability to enter custom server URL for CLI during login

### DIFF
--- a/src/commands/wallet/remove.ts
+++ b/src/commands/wallet/remove.ts
@@ -4,5 +4,7 @@ export const removeWallet = () => {
   console.log("disconnecting wallet");
   const db = getDb();
   db.set("config.token", null).write();
+  db.set("config.authUrl", null).write();
+  db.set("config.authPort", null).write();
   console.log("user logged out");
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { run as runLogin } from './commands/login'
 import { run as runSelfUpdate } from './commands/self-update'
 
 import { openInBrowser } from './lib/browser'
-import { getConsoleServer } from './lib/urls'
+import { getGatewayUrl } from './lib/urls'
 import { logger } from './lib/logger'
 import { sitesCli } from './commands/sites'
 
@@ -69,11 +69,21 @@ function createCLI(argv: string[]) {
     'Logs into your blockless account',
     (yargs) => {
       return yargs
+        .option('auth-url', {
+          alias: 'u',
+          description: 'Include an authentication host with your login command',
+          default: 'dashboard.blockless.network'
+        })
+        .option('auth-port', {
+          alias: 'p',
+          description: 'Include an authentication port with your login command',
+          default: 443
+        })
         .option('auth-token', {
           alias: 't',
           description: 'Include an authentication token with your login command',
         })
-        .group(['auth-token'], 'Options:')
+        .group(['auth-url', 'auth-port', 'auth-token'], 'Options:')
     },
     (argv) => {
       runLogin(argv)
@@ -103,7 +113,7 @@ function createCLI(argv: string[]) {
     'Opens the Console in the browser',
     () => { },
     async () => {
-      await openInBrowser(getConsoleServer())
+      await openInBrowser(getGatewayUrl())
     }
   )
 

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,12 +1,8 @@
 import axios from "axios"
-import Chalk from 'chalk'
 import { getToken } from "../store/db"
-import { getConsoleServer } from "./urls"
-
-const consoleServer = getConsoleServer()
+import { getGatewayUrl } from "./urls"
 
 export const consoleClient = axios.create({
-    baseURL: consoleServer,
     headers: {
         'Content-Type': 'application/json'
     }
@@ -18,6 +14,9 @@ export const consoleClient = axios.create({
  */
 consoleClient.interceptors.request.use(async (config) => {
     const token = getToken()
+    const gatewayUrl = getGatewayUrl()
+
+    config.baseURL = gatewayUrl
 
     if (token) {
         config.headers = {

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -1,3 +1,5 @@
+import { getAuthUrl } from "../store/db"
+
 // Console API Server
 export const getConsoleServer = (
   port?: number
@@ -6,6 +8,13 @@ export const getConsoleServer = (
   const host = devMode ? "http://0.0.0.0" : "https://dashboard.blockless.network";
   return `${host}:${port ? port : devMode ? 3005 : 443}`;
 };
+
+export const getGatewayUrl = (): string => {
+  const authUrl = getAuthUrl()
+  const protocol = authUrl.port === 443 ? 'https' : 'http'
+
+  return authUrl ? `${protocol}://${authUrl.url}:${authUrl.port}` : getConsoleServer() 
+}
 
 // WASI Repo Server
 export const getWASMRepoServer = (


### PR DESCRIPTION
Allow users to define a specific server/gateway URL during login. All request for that session will be router through the API for the particular server/gateway.

This feature helps in deploying functions to local / staging servers as well.