### PR TITLE
Framework selection and setup on sites init command

### DIFF
--- a/src/commands/sites/fameworks.ts
+++ b/src/commands/sites/fameworks.ts
@@ -1,0 +1,103 @@
+import { execSync } from "child_process"
+import fs from 'fs'
+import path from 'path'
+
+interface IFrameworkConfig {
+  build: string
+  publicDir: string
+}
+
+interface IFramework {
+  id: string
+  name: string
+  command: (pm: string, name: string) => string
+  postCommand: ((pm: string, path: string) => void) | null
+  config: IFrameworkConfig
+}
+
+const frameworks: IFramework[] = [
+  {
+    id: 'react',
+    name: 'React',
+    command: (pm, name) => `${pm} create-react-app ${name}`,
+    postCommand: null,
+    config: {
+      build: 'npm run build',
+      publicDir: 'build'
+    }
+  },
+  {
+    id: 'nextjs',
+    name: 'Next.js',
+    command: (pm, name) => `${pm} create-next-app ${name}`,
+    postCommand: (pm, installationPath) => {
+      const nextConfigPath = path.resolve(installationPath, 'next.config.js');
+
+      // Read the existing configuration file
+      const nextConfig = require(nextConfigPath);
+
+      // Make changes to the configuration object
+      nextConfig.output = 'export';
+      nextConfig.images = {
+        unoptimized: true
+      }
+
+      // Write the updated configuration back to the file
+      fs.writeFileSync(nextConfigPath, `module.exports = ${JSON.stringify(nextConfig, null, 2)};`, 'utf8');
+    },
+    config: {
+      build: 'npm run build',
+      publicDir: 'out'
+    }
+  },
+  {
+    id: 'vue',
+    name: 'Vue',
+    command: (pm, name) => `${pm} create-vue@3 ${name}`,
+    postCommand: null,
+    config: {
+      build: 'npm run build',
+      publicDir: 'dist'
+    }
+  }
+]
+
+/**
+ * Fetch a list of supported site frameworks
+ * 
+ * @returns 
+ */
+export function listFrameworks() {
+  return frameworks.map(f => ({ id: f.id, name: f.name }))
+}
+
+/**
+ * 
+ * @param id 
+ * @param path 
+ * @param name 
+ */
+export async function generateFramework({
+  id,
+  name,
+  path,
+  installationPath
+}: {
+  id: string,
+  name: string,
+  path: string,
+  installationPath: string
+}): Promise<IFrameworkConfig> {
+  const framework = frameworks.find(f => f.id === id)
+  if (!framework) throw new Error("Unable to detect framework.");
+  
+  // Run framework genration command
+  execSync(framework.command('npx', name), { cwd: path, stdio: 'inherit' })
+
+  // Run framework configuration command
+  if (framework.postCommand) {
+    framework.postCommand('npx', installationPath)
+  }
+
+  return framework.config
+}

--- a/src/commands/sites/preview.ts
+++ b/src/commands/sites/preview.ts
@@ -5,6 +5,7 @@ import { execSync } from "child_process"
 import { resolve } from "path"
 import { parseBlsConfig } from "../../lib/blsConfig"
 import { logger } from "../../lib/logger"
+import { run as runBuild } from "./build"
 import { run as runInstall } from "../offchain/install"
 import prompRuntimeConfirm from "../../prompts/runtime/confirm"
 import Fastify from "fastify"
@@ -43,6 +44,9 @@ export const run = async (options: any) => {
   try {
     // Fetch BLS config
     const { build, build_release } = parseBlsConfig()
+
+    // Execute the build command
+    runBuild({ path, debug, rebuild })
 
     // check for and store unmodified wasm file name to change later
     const buildConfig = !debug ? build_release : build

--- a/src/lib/blsConfig.ts
+++ b/src/lib/blsConfig.ts
@@ -20,8 +20,7 @@ export const generateBaseConfig = ({
         version,
 
         deployment: {
-            permission: isPrivate ? 'private' : 'public',
-            nodes: 4
+            nodes: 1
         }
     } as JsonMap
 

--- a/src/prompts/sites/init.ts
+++ b/src/prompts/sites/init.ts
@@ -1,6 +1,7 @@
 import fs from "fs"
 import prompts from "prompts"
 import { randomName } from "../../lib/randomName"
+import { listFrameworks } from "../../commands/sites/fameworks"
 
 interface PromptDeployOptions {
     name: string,
@@ -9,13 +10,10 @@ interface PromptDeployOptions {
 
 interface PromptDeployOutput {
     name: string
-    template: string
+    framework: string
 }
 
-const templates = [
-  { title: 'Hello World', value: 'https://github.com/blocklessnetwork/template-site-hello-world' },
-  { title: 'Next.js', value: 'https://github.com/blocklessnetwork/template-site-nextjs' }
-]
+const frameworks = listFrameworks().map(f => ({ title: f.name, value: f.id }))
 
 const promptSitesInit = async (options: PromptDeployOptions): Promise<PromptDeployOutput | null> => {
     try {
@@ -40,9 +38,9 @@ const promptSitesInit = async (options: PromptDeployOptions): Promise<PromptDepl
             [
                 {
                     type: 'select',
-                    name: 'template',
-                    message: 'Pick a starter template',
-                    choices: templates,
+                    name: 'framework',
+                    message: 'Pick a framework',
+                    choices: frameworks,
                     initial: 0
                 }
             ],
@@ -52,7 +50,7 @@ const promptSitesInit = async (options: PromptDeployOptions): Promise<PromptDepl
                     process.exit(1)
                 }
             }
-        ) : { template: null }
+        ) : { framework: null }
 
         return {
             ...nameResponse,


### PR DESCRIPTION
This PR allows users to initialize a new sites project by selecting a static site framework. 
Three frameworks are supported in this PR, 
1. React (Create react app)
2. Next.js
3. Vue

More frameworks to be introduced in future